### PR TITLE
Dependency to ros_conrtol is removed since it looks like not used

### DIFF
--- a/agvs_control/CMakeLists.txt
+++ b/agvs_control/CMakeLists.txt
@@ -4,10 +4,10 @@ project(agvs_control)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-#find_package(catkin REQUIRED COMPONENTS
-#  ros_control
+find_package(catkin REQUIRED COMPONENTS
+#  ros_control 
 #  ros_controllers
-#)
+)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -78,12 +78,12 @@ project(agvs_control)
 ## LIBRARIES: libraries you create in this project that dependent projects also need
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
-catkin_package(
+#catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES agvs_control
 #  CATKIN_DEPENDS ros_control ros_controllers
 #  DEPENDS system_lib
-)
+#)
 
 ###########
 ## Build ##


### PR DESCRIPTION
Without this catkin doesn't pass with the following error:

```
[agvs_control] ==> '/home/rostapas/cws/build/agvs_control/build_env.sh /usr/bin/cmake /home/rostapas/cws/src/RobotnikAutomation/agvs/agvs_control -DCATKIN_DEVEL_PREFIX=/home/rostapas/cws/devel -DCMAKE_INSTALL_PREFIX=/home/rostapas/cws/install' in '/home/rostapas/cws/build/agvs_control'
CMake Error at CMakeLists.txt:81 (catkin_package):
  Unknown CMake command "catkin_package".
```
